### PR TITLE
Merge duplicate frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Changelog
 
+## v0.2.1
+
+- Merge identical consecutive frames when reading animations.
+- Warn about and discard 0-second frames when reading animations.
+- Bump the version of libwebp2 in deps.sh.
+
 ## v0.2.0
 
 - Add animation support.
 - Replace the libwebp2 wrapper in codec_webp by libwebp API calls to save a
   buffer copy.
 - Use SharpYUV with the WebP codec.
+- Bump the version of libwebp2 in deps.sh.
 
 ## v0.1.5
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ cmake_minimum_required(VERSION 3.20)
 project(
   codec-compare-gen
   LANGUAGES CXX
-  VERSION 0.2.0)
+  VERSION 0.2.1)
 set(CMAKE_CXX_STANDARD 17)
 
 option(BUILD_SHARED_LIBS "Build the shared codec-compare-gen library" ON)
@@ -148,6 +148,7 @@ if(BUILD_TESTING)
     add_executable(${TEST_NAME} tests/${TEST_NAME}.cc)
     target_include_directories(${TEST_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
     target_link_libraries(${TEST_NAME} PRIVATE libccgen GTest::gtest)
+    target_compile_definitions(${TEST_NAME} PRIVATE HAS_WEBP2)
     if(${ARGC} EQUAL 2)
       add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME}
                                          ${CMAKE_CURRENT_SOURCE_DIR}/${ARGV1}/)
@@ -160,6 +161,7 @@ if(BUILD_TESTING)
   add_ccgen_gtest(test_codec tests/data)
   add_ccgen_gtest(test_codec_avif)
   add_ccgen_gtest(test_codec_sjpeg tests/data)
+  add_ccgen_gtest(test_distortion tests/data)
   add_ccgen_gtest(test_framework tests/data)
   add_ccgen_gtest(test_serialization)
   add_ccgen_gtest(test_task)

--- a/deps.sh
+++ b/deps.sh
@@ -63,7 +63,7 @@ pushd third_party
 
   git clone https://chromium.googlesource.com/codecs/libwebp2
   pushd libwebp2
-    git checkout 1b2f59ec66652300548774ad57b18073c567f23e
+    git checkout b65d168d3b2b8f8ec849134da2c3a5f034f1eb42
     cmake -S . -B build \
       -DCMAKE_PREFIX_PATH="../libwebp/src/;../libwebp/build/" \
       -DWP2_BUILD_TESTS=OFF \

--- a/src/codec_webp.cc
+++ b/src/codec_webp.cc
@@ -178,7 +178,7 @@ StatusOr<WP2::Data> EncodeWebp(const TaskInput& input,
       timestamp_ms += static_cast<int>(frame.duration_ms);
     }
     CHECK_OR_RETURN(
-        WebPAnimEncoderAdd(enc.get(), nullptr, timestamp_ms, nullptr), quiet);
+        WebPAnimEncoderAdd(enc.get(), nullptr, timestamp_ms, &config), quiet);
     WebPData webp_data;
     WebPDataInit(&webp_data);
     CHECK_OR_RETURN(WebPAnimEncoderAssemble(enc.get(), &webp_data), quiet);

--- a/src/codec_webp2.cc
+++ b/src/codec_webp2.cc
@@ -68,7 +68,7 @@ StatusOr<WP2::Data> EncodeWebp2(const TaskInput& input,
   if (input.codec_settings.quality == kQualityLossless) {
     config.quality = 100.0f;
     config.alpha_quality = 100.0f;
-    config.exact = true;
+    config.keep_unmultiplied = true;
     config.tile_shape = WP2::TILE_SHAPE_WIDE;
   } else {
     config.quality = input.codec_settings.quality;
@@ -120,9 +120,6 @@ StatusOr<std::pair<Image, double>> DecodeWebp2(const TaskInput& input,
   //         undefined reference to typeinfo for WP2::Decoder
 
   WP2::DecoderConfig config;
-  if (input.codec_settings.quality == kQualityLossless) {
-    config.exact = true;
-  }
   config.thread_level = 0;
   WP2::ArrayDecoder decoder(encoded_image.bytes, encoded_image.size, config);
   Image image;

--- a/src/distortion.h
+++ b/src/distortion.h
@@ -22,6 +22,10 @@
 #include "src/frame.h"
 #include "src/task.h"
 
+#if defined(HAS_WEBP2)
+#include "third_party/libwebp2/src/wp2/base.h"
+#endif
+
 namespace codec_compare_gen {
 
 // Computes the average distortion between the given frame sequences.
@@ -31,6 +35,14 @@ StatusOr<float> GetAverageDistortion(
     const std::string& image_path, const Image& image, const TaskInput& task,
     const std::string& metric_binary_folder_path, DistortionMetric metric,
     size_t thread_id, bool quiet);
+
+// Returns true if all pixels match between the two given frame sequences.
+StatusOr<bool> PixelEquality(const Image& a, const Image& b, bool quiet);
+
+#if defined(HAS_WEBP2)
+StatusOr<bool> PixelEquality(const WP2::ArgbBuffer& a, const WP2::ArgbBuffer& b,
+                             bool quiet);
+#endif
 
 }  // namespace codec_compare_gen
 

--- a/tests/test_distortion.cc
+++ b/tests/test_distortion.cc
@@ -1,0 +1,91 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstddef>
+#include <iostream>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "src/base.h"
+#include "src/distortion.h"
+#include "src/frame.h"
+#include "third_party/libwebp2/src/wp2/base.h"
+
+namespace codec_compare_gen {
+namespace {
+
+// Used to pass the data folder path to the GoogleTest suites.
+const char* data_path = nullptr;
+
+constexpr bool kQuiet = false;
+constexpr size_t kThreadId = 0;
+
+//------------------------------------------------------------------------------
+
+TEST(DistortionTest, Same) {
+  const std::string gif_path = std::string(data_path) + "anim80x80.gif";
+  const StatusOr<Image> gif =
+      ReadStillImageOrAnimation(gif_path.c_str(), WP2_ARGB_32, kQuiet);
+  ASSERT_EQ(gif.status, Status::kOk);
+
+  const StatusOr<bool> equality = PixelEquality(gif.value, gif.value, kQuiet);
+  ASSERT_EQ(equality.status, Status::kOk);
+  EXPECT_TRUE(equality.value);
+
+  const StatusOr<float> distortion =
+      GetAverageDistortion("", gif.value, "", gif.value, {}, "",
+                           DistortionMetric::kLibwebp2Psnr, kThreadId, kQuiet);
+  ASSERT_EQ(distortion.status, Status::kOk);
+  EXPECT_EQ(distortion.value, kNoDistortion);
+}
+
+TEST(DistortionTest, Different) {
+  const std::string gif_path = std::string(data_path) + "anim80x80.gif";
+  const std::string webp_path = std::string(data_path) + "anim80x80.webp";
+  const StatusOr<Image> gif =
+      ReadStillImageOrAnimation(gif_path.c_str(), WP2_ARGB_32, kQuiet);
+  ASSERT_EQ(gif.status, Status::kOk);
+  const StatusOr<Image> webp =
+      ReadStillImageOrAnimation(webp_path.c_str(), WP2_ARGB_32, kQuiet);
+  ASSERT_EQ(webp.status, Status::kOk);
+
+  const StatusOr<bool> equality = PixelEquality(gif.value, webp.value, kQuiet);
+  ASSERT_EQ(equality.status, Status::kOk);
+  EXPECT_FALSE(equality.value);
+
+  const StatusOr<float> distortion =
+      GetAverageDistortion("", gif.value, "", webp.value, {}, "",
+                           DistortionMetric::kLibwebp2Psnr, kThreadId, kQuiet);
+  ASSERT_EQ(distortion.status, Status::kOk);
+  // Expect a distortion equivalent to GIF not supporting translucency.
+  EXPECT_LT(distortion.value, kNoDistortion);
+  EXPECT_GT(distortion.value, 20.0f);
+}
+
+//------------------------------------------------------------------------------
+
+}  // namespace
+}  // namespace codec_compare_gen
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  if (argc != 2) {
+    std::cerr << "There must be exactly one argument containing the path to "
+                 "the test data folder"
+              << std::endl;
+    return 1;
+  }
+  codec_compare_gen::data_path = argv[1];
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Skip 0-second frames.
Bump libwebp2 dependency to use the latest unpremultiplied paths. Bump version.