### PR TITLE
Add 4:2:0 J2K support with OpenJPEG API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.5
+
+- Add JPEG 2000 4:2:0 support through OpenJPEG.
+
 ## v0.5.4
 
 - Add JPEG 2000 support through OpenJPEG (4:4:4 only).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ cmake_minimum_required(VERSION 3.20)
 project(
   codec-compare-gen
   LANGUAGES CXX
-  VERSION 0.5.4)
+  VERSION 0.5.5)
 set(CMAKE_CXX_STANDARD 17)
 
 option(BUILD_SHARED_LIBS "Build the shared codec-compare-gen library" ON)

--- a/src/result_json.cc
+++ b/src/result_json.cc
@@ -140,7 +140,7 @@ Status TasksToJson(const std::string& batch_pretty_name, CodecSettings settings,
             " && mv third_party/libavif_avm third_party/libavif"
           : "";
   const std::string build_cmd =
-      "git clone -b v0.5.4 --depth 1"
+      "git clone -b v0.5.5 --depth 1"
       " https://github.com/webmproject/codec-compare-gen.git"
       " && cd codec-compare-gen && ./deps.sh" +
       deps_extra_step +


### PR DESCRIPTION
It seems to match the output file size of
  opj_compress -i in.png -o out.jp2 -r {101-q} -s 2,2