### PR TITLE
Process safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.5.11
+
+- Make GetAverageDistortion() process-safe on Unix platforms.
+- Bump the version of libwebp in deps.sh.
+- Bump the version of libwebp2 in deps.sh.
+
 ## v0.5.10
 
 - Only read files with extensions .jpg, .jpeg, .png and .webp.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ cmake_minimum_required(VERSION 3.20)
 project(
   codec-compare-gen
   LANGUAGES CXX
-  VERSION 0.5.10)
+  VERSION 0.5.11)
 set(CMAKE_CXX_STANDARD 17)
 
 option(BUILD_SHARED_LIBS "Build the shared codec-compare-gen library" ON)
@@ -74,6 +74,9 @@ add_library(
   src/timer.h
   src/worker.h)
 target_include_directories(libccgen PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+if(NOT WIN32)
+  target_compile_definitions(libccgen PRIVATE HAVE_UNISTD_H)
+endif()
 
 # Dependencies
 

--- a/deps.sh
+++ b/deps.sh
@@ -67,7 +67,7 @@ pushd third_party
 
   git clone https://chromium.googlesource.com/webm/libwebp
   pushd libwebp
-    git checkout a4d7a715337ded4451fec90ff8ce79728e04126c # v1.5.0
+    git checkout b7e29b9d75bd31422b00c2a446d49d7af06c328d # v1.6.0
     cmake -S . -B build \
       -DWEBP_BUILD_CWEBP=ON \
       -DWEBP_BUILD_DWEBP=ON \
@@ -82,7 +82,7 @@ pushd third_party
 
   git clone https://chromium.googlesource.com/codecs/libwebp2
   pushd libwebp2
-    git checkout 75878e84787870b62786e3de1f02da7ba0e40b5c
+    git checkout aa3651e5c43a2c22d75ba500e01a016c49fb0bdf
     cmake -S . -B build \
       -DCMAKE_PREFIX_PATH="../libwebp/src/;../libwebp/build/" \
       -DWP2_BUILD_TESTS=OFF \
@@ -127,6 +127,8 @@ pushd third_party
   # FFV1 is part of FFmpeg.
   git clone -b n7.1.1 --depth 1 https://github.com/FFmpeg/FFmpeg.git
   pushd FFmpeg
+    # n8.0 leads to "error while loading shared libraries: libswresample.so.6:
+    #                cannot open shared object file: No such file or directory"
     git checkout db69d06eeeab4f46da15030a80d539efb4503ca8 # n7.1.1
     ./configure --prefix=build --enable-shared --disable-static
     make libavcodec -j${NPROC}

--- a/src/codec.cc
+++ b/src/codec.cc
@@ -41,7 +41,6 @@
 #include "src/distortion.h"
 #include "src/frame.h"
 #include "src/framework.h"
-#include "src/serialization.h"
 #include "src/task.h"
 #include "src/timer.h"
 


### PR DESCRIPTION
Previously temporary file names were thread-safe only. Bump dependencies.